### PR TITLE
Problem: when used with defaults language offset is -1 which causes out_of_bounds exception

### DIFF
--- a/src/fty_common_translation_base.cc
+++ b/src/fty_common_translation_base.cc
@@ -333,6 +333,7 @@ void Translation::configure (const std::string &agent_name, const std::string &p
     }
     file_prefix_ = file_prefix;
     loadLanguage (default_language_);
+    language_order_ = 0;
 }
 
 


### PR DESCRIPTION
Solution: set proper offset during configuration