### PR TITLE
[IPMVAL-2341] Fix appending component-provided translations in locale…

### DIFF
--- a/collect_translations.sh
+++ b/collect_translations.sh
@@ -62,8 +62,13 @@ done
 # Check if projects include "src/locale_en_US.json" files, and store content for further processing
 rm -f BE_projects_locale_en_US.json
 for FILE in $(find "${TARGET}" -name locale_en_US.json | grep -v "weblate"); do
+    if [ ! -s "${FILE}" ]; then
+        echo "SKIP: Invalid project-provided translations ($FILE)"
+        continue
+    fi
     echo "Processing projects provided translations ($FILE)"
-    # Remove JSON struct lines
+    # Remove JSON struct lines around the contents; prefix with "," to follow existing JSON in final target file
+    echo "," >> BE_projects_locale_en_US.json
     sed -e '/^{/d; /^\}/d' "${FILE}" >> BE_projects_locale_en_US.json
 done
 # remove empty lines and duplicates


### PR DESCRIPTION
…_en_US.json generated by etn-translations scripts

Currently we have a couple of components that add translations to our localized data (and over time likely more will do so). The first shot at generating locale_en_US.json was to strip the surrounding braces from those original localizations and inserting the file contents - and we ended up with invalid JSON markup like:

````
"key1": "value1"
"key2": "value2"
````

with no comma between them.